### PR TITLE
Fix urljoin test

### DIFF
--- a/tests/test_scurl.py
+++ b/tests/test_scurl.py
@@ -69,7 +69,7 @@ class UrljoinTestCase(unittest.TestCase):
 
         for base in bases:
             for url in urls:
-                self.assertRaises(ValueError)
+                self.assertRaises(ValueError, scurl.urljoin, base, url)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR aims to resolve the issue #55 , which fixes the urljoin tests that does not test anything (assertRaises without func name and params)