### PR TITLE
WIP: use original tests from urllib

### DIFF
--- a/tests/test_urlparse_py3.py
+++ b/tests/test_urlparse_py3.py
@@ -1,22 +1,16 @@
 # https://github.com/python/cpython/blob/9863de0355caf23c44b708a5d68b603e135f7ae9/Lib/test/test_urlparse.py
 
+from test import test_support
 import unittest
-import scurl
-import warnings
-import pytest
-import sys
-import six
-
-if six.PY2:
-    pytest.skip("Env is python2, skipping python3 tests", allow_module_level=True)
+import scurl as urlparse
 
 RFC1808_BASE = "http://a/b/c/d;p?q#f"
 RFC2396_BASE = "http://a/b/c/d;p?q"
 RFC3986_BASE = 'http://a/b/c/d;p?q'
 SIMPLE_BASE  = 'http://a/b/c/d'
 
-# Each parse_qsl testcase is a two-tuple that contains
-# a string with the query and a list with the expected result.
+# A list of test cases.  Each test case is a two-tuple that contains
+# a string with the query and a dictionary with the expected result.
 
 parse_qsl_test_cases = [
     ("", []),
@@ -26,19 +20,10 @@ parse_qsl_test_cases = [
     ("=a", [('', 'a')]),
     ("a", [('a', '')]),
     ("a=", [('a', '')]),
+    ("a=", [('a', '')]),
     ("&a=b", [('a', 'b')]),
     ("a=a+b&b=b+c", [('a', 'a b'), ('b', 'b c')]),
     ("a=1&a=2", [('a', '1'), ('a', '2')]),
-    (b"", []),
-    (b"&", []),
-    (b"&&", []),
-    (b"=", [(b'', b'')]),
-    (b"=a", [(b'', b'a')]),
-    (b"a", [(b'a', b'')]),
-    (b"a=", [(b'a', b'')]),
-    (b"&a=b", [(b'a', b'b')]),
-    (b"a=a+b&b=b+c", [(b'a', b'a b'), (b'b', b'b c')]),
-    (b"a=1&a=2", [(b'a', b'1'), (b'a', b'2')]),
     (";", []),
     (";;", []),
     (";a=b", [('a', 'b')]),
@@ -50,9 +35,6 @@ parse_qsl_test_cases = [
     (b"a=a+b;b=b+c", [(b'a', b'a b'), (b'b', b'b c')]),
     (b"a=1;a=2", [(b'a', b'1'), (b'a', b'2')]),
 ]
-
-# Each parse_qs testcase is a two-tuple that contains
-# a string with the query and a dictionary with the expected result.
 
 parse_qs_test_cases = [
     ("", {}),
@@ -90,19 +72,19 @@ parse_qs_test_cases = [
 class UrlParseTestCase(unittest.TestCase):
 
     def checkRoundtrips(self, url, parsed, split):
-        result = scurl.urlparse(url)
+        result = urlparse.urlparse(url)
         self.assertEqual(result, parsed)
         t = (result.scheme, result.netloc, result.path,
              result.params, result.query, result.fragment)
         self.assertEqual(t, parsed)
         # put it back together and it should be the same
-        result2 = scurl.urlunparse(result)
+        result2 = urlparse.urlunparse(result)
         self.assertEqual(result2, url)
         self.assertEqual(result2, result.geturl())
 
         # the result of geturl() is a fixpoint; we can always parse it
         # again to get the same result:
-        result3 = scurl.urlparse(result.geturl())
+        result3 = urlparse.urlparse(result.geturl())
         self.assertEqual(result3.geturl(), result.geturl())
         self.assertEqual(result3,          result)
         self.assertEqual(result3.scheme,   result.scheme)
@@ -117,17 +99,17 @@ class UrlParseTestCase(unittest.TestCase):
         self.assertEqual(result3.port,     result.port)
 
         # check the roundtrip using urlsplit() as well
-        result = scurl.urlsplit(url)
+        result = urlparse.urlsplit(url)
         self.assertEqual(result, split)
         t = (result.scheme, result.netloc, result.path,
              result.query, result.fragment)
         self.assertEqual(t, split)
-        result2 = scurl.urlunsplit(result)
+        result2 = urlparse.urlunsplit(result)
         self.assertEqual(result2, url)
         self.assertEqual(result2, result.geturl())
 
         # check the fixpoint property of re-parsing the result of geturl()
-        result3 = scurl.urlsplit(result.geturl())
+        result3 = urlparse.urlsplit(result.geturl())
         self.assertEqual(result3.geturl(), result.geturl())
         self.assertEqual(result3,          result)
         self.assertEqual(result3.scheme,   result.scheme)
@@ -142,26 +124,25 @@ class UrlParseTestCase(unittest.TestCase):
 
     def test_qsl(self):
         for orig, expect in parse_qsl_test_cases:
-            result = scurl.parse_qsl(orig, keep_blank_values=True)
+            result = urlparse.parse_qsl(orig, keep_blank_values=True)
             self.assertEqual(result, expect, "Error parsing %r" % orig)
             expect_without_blanks = [v for v in expect if len(v[1])]
-            result = scurl.parse_qsl(orig, keep_blank_values=False)
+            result = urlparse.parse_qsl(orig, keep_blank_values=False)
             self.assertEqual(result, expect_without_blanks,
-                            "Error parsing %r" % orig)
+                    "Error parsing %r" % orig)
 
     def test_qs(self):
         for orig, expect in parse_qs_test_cases:
-            result = scurl.parse_qs(orig, keep_blank_values=True)
+            result = urlparse.parse_qs(orig, keep_blank_values=True)
             self.assertEqual(result, expect, "Error parsing %r" % orig)
-            expect_without_blanks = {v: expect[v]
-                                     for v in expect if len(expect[v][0])}
-            result = scurl.parse_qs(orig, keep_blank_values=False)
+            expect_without_blanks = dict(
+                    [(v, expect[v]) for v in expect if len(expect[v][0])])
+            result = urlparse.parse_qs(orig, keep_blank_values=False)
             self.assertEqual(result, expect_without_blanks,
-                            "Error parsing %r" % orig)
+                    "Error parsing %r" % orig)
 
-    @pytest.mark.xfail(reason="GURL failed to parse these schemes for now")
     def test_roundtrips(self):
-        str_cases = [
+        testcases = [
             ('file:///tmp/junk.txt',
              ('file', '', '/tmp/junk.txt', '', '', ''),
              ('file', '', '/tmp/junk.txt', '', '')),
@@ -174,7 +155,7 @@ class UrlParseTestCase(unittest.TestCase):
              ('mms', 'wms.sys.hinet.net', '/cts/Drama/09006251100.asf',
               '', '')),
             ('nfs://server/path/to/file.txt',
-             ('nfs', 'server', '/path/to/file.txt', '', '', ''),
+             ('nfs', 'server', '/path/to/file.txt',  '', '', ''),
              ('nfs', 'server', '/path/to/file.txt', '', '')),
             ('svn+ssh://svn.zope.org/repos/main/ZConfig/trunk/',
              ('svn+ssh', 'svn.zope.org', '/repos/main/ZConfig/trunk/',
@@ -185,21 +166,16 @@ class UrlParseTestCase(unittest.TestCase):
             ('git+ssh', 'git@github.com','/user/project.git',
              '','',''),
             ('git+ssh', 'git@github.com','/user/project.git',
-             '', '')),
+             '', ''))
             ]
-        def _encode(t):
-            return (t[0].encode('ascii'),
-                    tuple(x.encode('ascii') for x in t[1]),
-                    tuple(x.encode('ascii') for x in t[2]))
-        bytes_cases = [_encode(x) for x in str_cases]
-        for url, parsed, split in str_cases + bytes_cases:
+        for url, parsed, split in testcases:
             self.checkRoundtrips(url, parsed, split)
 
     def test_http_roundtrips(self):
-        # scurl.urlsplit treats 'http:' as an optimized special case,
+        # urlparse.urlsplit treats 'http:' as an optimized special case,
         # so we test both 'http:' and 'https:' in all the following.
         # Three cheers for white box knowledge!
-        str_cases = [
+        testcases = [
             ('://www.python.org',
              ('www.python.org', '', '', '', ''),
              ('www.python.org', '', '', '')),
@@ -216,36 +192,21 @@ class UrlParseTestCase(unittest.TestCase):
              ('a', '/b/c/d', 'p', 'q', 'f'),
              ('a', '/b/c/d;p', 'q', 'f')),
             ]
-        def _encode(t):
-            return (t[0].encode('ascii'),
-                    tuple(x.encode('ascii') for x in t[1]),
-                    tuple(x.encode('ascii') for x in t[2]))
-        bytes_cases = [_encode(x) for x in str_cases]
-        str_schemes = ('http', 'https')
-        bytes_schemes = (b'http', b'https')
-        str_tests = str_schemes, str_cases
-        bytes_tests = bytes_schemes, bytes_cases
-        for schemes, test_cases in (str_tests, bytes_tests):
-            for scheme in schemes:
-                for url, parsed, split in test_cases:
-                    url = scheme + url
-                    parsed = (scheme,) + parsed
-                    split = (scheme,) + split
-                    self.checkRoundtrips(url, parsed, split)
+        for scheme in ('http', 'https'):
+            for url, parsed, split in testcases:
+                url = scheme + url
+                parsed = (scheme,) + parsed
+                split = (scheme,) + split
+                self.checkRoundtrips(url, parsed, split)
 
     def checkJoin(self, base, relurl, expected):
-        str_components = (base, relurl, expected)
-        self.assertEqual(scurl.urljoin(base, relurl), expected)
-        bytes_components = baseb, relurlb, expectedb = [
-                            x.encode('ascii') for x in str_components]
-        self.assertEqual(scurl.urljoin(baseb, relurlb), expectedb)
+        self.assertEqual(urlparse.urljoin(base, relurl), expected,
+                         (base, relurl, expected))
 
     def test_unparse_parse(self):
-        str_cases = ['Python', './Python','x-newscheme://foo.com/stuff','x://y','x:/y','x:/','/',]
-        bytes_cases = [x.encode('ascii') for x in str_cases]
-        for u in str_cases + bytes_cases:
-            self.assertEqual(scurl.urlunsplit(scurl.urlsplit(u)), u)
-            self.assertEqual(scurl.urlunparse(scurl.urlparse(u)), u)
+        for u in ['Python', './Python','x-newscheme://foo.com/stuff','x://y','x:/y','x:/','/',]:
+            self.assertEqual(urlparse.urlunsplit(urlparse.urlsplit(u)), u)
+            self.assertEqual(urlparse.urlunparse(urlparse.urlparse(u)), u)
 
     def test_RFC1808(self):
         # "normal" cases from RFC 1808:
@@ -254,7 +215,7 @@ class UrlParseTestCase(unittest.TestCase):
         self.checkJoin(RFC1808_BASE, './g', 'http://a/b/c/g')
         self.checkJoin(RFC1808_BASE, 'g/', 'http://a/b/c/g/')
         self.checkJoin(RFC1808_BASE, '/g', 'http://a/g')
-        self.checkJoin(RFC1808_BASE, '//g', 'http://g/')
+        self.checkJoin(RFC1808_BASE, '//g', 'http://g')
         self.checkJoin(RFC1808_BASE, 'g?y', 'http://a/b/c/g?y')
         self.checkJoin(RFC1808_BASE, 'g?y/./x', 'http://a/b/c/g?y/./x')
         self.checkJoin(RFC1808_BASE, '#s', 'http://a/b/c/d;p?q#s')
@@ -273,6 +234,11 @@ class UrlParseTestCase(unittest.TestCase):
         self.checkJoin(RFC1808_BASE, '../../g', 'http://a/g')
 
         # "abnormal" cases from RFC 1808:
+        self.checkJoin(RFC1808_BASE, '', 'http://a/b/c/d;p?q#f')
+        self.checkJoin(RFC1808_BASE, '../../../g', 'http://a/../g')
+        self.checkJoin(RFC1808_BASE, '../../../../g', 'http://a/../../g')
+        self.checkJoin(RFC1808_BASE, '/./g', 'http://a/./g')
+        self.checkJoin(RFC1808_BASE, '/../g', 'http://a/../g')
         self.checkJoin(RFC1808_BASE, 'g.', 'http://a/b/c/g.')
         self.checkJoin(RFC1808_BASE, '.g', 'http://a/b/c/.g')
         self.checkJoin(RFC1808_BASE, 'g..', 'http://a/b/c/g..')
@@ -287,27 +253,19 @@ class UrlParseTestCase(unittest.TestCase):
         #self.checkJoin(RFC1808_BASE, 'http:g', 'http:g')
         #self.checkJoin(RFC1808_BASE, 'http:', 'http:')
 
-        # XXX: The following tests are no longer compatible with RFC3986
-        # self.checkJoin(RFC1808_BASE, '../../../g', 'http://a/../g')
-        # self.checkJoin(RFC1808_BASE, '../../../../g', 'http://a/../../g')
-        # self.checkJoin(RFC1808_BASE, '/./g', 'http://a/./g')
-        # self.checkJoin(RFC1808_BASE, '/../g', 'http://a/../g')
-
-
     def test_RFC2368(self):
         # Issue 11467: path that starts with a number is not parsed correctly
-        self.assertEqual(scurl.urlparse('mailto:1337@example.org'),
+        self.assertEqual(urlparse.urlparse('mailto:1337@example.org'),
                 ('mailto', '', '1337@example.org', '', '', ''))
 
     def test_RFC2396(self):
         # cases from RFC 2396
-
         self.checkJoin(RFC2396_BASE, 'g:h', 'g:h')
         self.checkJoin(RFC2396_BASE, 'g', 'http://a/b/c/g')
         self.checkJoin(RFC2396_BASE, './g', 'http://a/b/c/g')
         self.checkJoin(RFC2396_BASE, 'g/', 'http://a/b/c/g/')
         self.checkJoin(RFC2396_BASE, '/g', 'http://a/g')
-        self.checkJoin(RFC2396_BASE, '//g', 'http://g/')
+        self.checkJoin(RFC2396_BASE, '//g', 'http://g')
         self.checkJoin(RFC2396_BASE, 'g?y', 'http://a/b/c/g?y')
         self.checkJoin(RFC2396_BASE, '#s', 'http://a/b/c/d;p?q#s')
         self.checkJoin(RFC2396_BASE, 'g#s', 'http://a/b/c/g#s')
@@ -323,6 +281,10 @@ class UrlParseTestCase(unittest.TestCase):
         self.checkJoin(RFC2396_BASE, '../../', 'http://a/')
         self.checkJoin(RFC2396_BASE, '../../g', 'http://a/g')
         self.checkJoin(RFC2396_BASE, '', RFC2396_BASE)
+        self.checkJoin(RFC2396_BASE, '../../../g', 'http://a/../g')
+        self.checkJoin(RFC2396_BASE, '../../../../g', 'http://a/../../g')
+        self.checkJoin(RFC2396_BASE, '/./g', 'http://a/./g')
+        self.checkJoin(RFC2396_BASE, '/../g', 'http://a/../g')
         self.checkJoin(RFC2396_BASE, 'g.', 'http://a/b/c/g.')
         self.checkJoin(RFC2396_BASE, '.g', 'http://a/b/c/.g')
         self.checkJoin(RFC2396_BASE, 'g..', 'http://a/b/c/g..')
@@ -338,21 +300,16 @@ class UrlParseTestCase(unittest.TestCase):
         self.checkJoin(RFC2396_BASE, 'g#s/./x', 'http://a/b/c/g#s/./x')
         self.checkJoin(RFC2396_BASE, 'g#s/../x', 'http://a/b/c/g#s/../x')
 
-        # XXX: The following tests are no longer compatible with RFC3986
-        # self.checkJoin(RFC2396_BASE, '../../../g', 'http://a/../g')
-        # self.checkJoin(RFC2396_BASE, '../../../../g', 'http://a/../../g')
-        # self.checkJoin(RFC2396_BASE, '/./g', 'http://a/./g')
-        # self.checkJoin(RFC2396_BASE, '/../g', 'http://a/../g')
-
     def test_RFC3986(self):
+        # Test cases from RFC3986
         self.checkJoin(RFC3986_BASE, '?y','http://a/b/c/d;p?y')
-        self.checkJoin(RFC3986_BASE, ';x', 'http://a/b/c/;x')
+        self.checkJoin(RFC2396_BASE, ';x', 'http://a/b/c/;x')
         self.checkJoin(RFC3986_BASE, 'g:h','g:h')
         self.checkJoin(RFC3986_BASE, 'g','http://a/b/c/g')
         self.checkJoin(RFC3986_BASE, './g','http://a/b/c/g')
         self.checkJoin(RFC3986_BASE, 'g/','http://a/b/c/g/')
         self.checkJoin(RFC3986_BASE, '/g','http://a/g')
-        self.checkJoin(RFC3986_BASE, '//g','http://g/')
+        self.checkJoin(RFC3986_BASE, '//g','http://g')
         self.checkJoin(RFC3986_BASE, '?y','http://a/b/c/d;p?y')
         self.checkJoin(RFC3986_BASE, 'g?y','http://a/b/c/g?y')
         self.checkJoin(RFC3986_BASE, '#s','http://a/b/c/d;p?q#s')
@@ -370,17 +327,17 @@ class UrlParseTestCase(unittest.TestCase):
         self.checkJoin(RFC3986_BASE, '../..','http://a/')
         self.checkJoin(RFC3986_BASE, '../../','http://a/')
         self.checkJoin(RFC3986_BASE, '../../g','http://a/g')
-        self.checkJoin(RFC3986_BASE, '../../../g', 'http://a/g')
 
-        # Abnormal Examples
+        #Abnormal Examples
 
         # The 'abnormal scenarios' are incompatible with RFC2986 parsing
         # Tests are here for reference.
 
-        self.checkJoin(RFC3986_BASE, '../../../g','http://a/g')
-        self.checkJoin(RFC3986_BASE, '../../../../g','http://a/g')
-        self.checkJoin(RFC3986_BASE, '/./g','http://a/g')
-        self.checkJoin(RFC3986_BASE, '/../g','http://a/g')
+        #self.checkJoin(RFC3986_BASE, '../../../g','http://a/g')
+        #self.checkJoin(RFC3986_BASE, '../../../../g','http://a/g')
+        #self.checkJoin(RFC3986_BASE, '/./g','http://a/g')
+        #self.checkJoin(RFC3986_BASE, '/../g','http://a/g')
+
         self.checkJoin(RFC3986_BASE, 'g.','http://a/b/c/g.')
         self.checkJoin(RFC3986_BASE, '.g','http://a/b/c/.g')
         self.checkJoin(RFC3986_BASE, 'g..','http://a/b/c/g..')
@@ -396,7 +353,7 @@ class UrlParseTestCase(unittest.TestCase):
         self.checkJoin(RFC3986_BASE, 'g#s/./x','http://a/b/c/g#s/./x')
         self.checkJoin(RFC3986_BASE, 'g#s/../x','http://a/b/c/g#s/../x')
         #self.checkJoin(RFC3986_BASE, 'http:g','http:g') # strict parser
-        self.checkJoin(RFC3986_BASE, 'http:g','http://a/b/c/g') #relaxed parser
+        self.checkJoin(RFC3986_BASE, 'http:g','http://a/b/c/g') # relaxed parser
 
         # Test for issue9721
         self.checkJoin('http://a/b/c/de', ';x','http://a/b/c/;x')
@@ -409,7 +366,7 @@ class UrlParseTestCase(unittest.TestCase):
         self.checkJoin(SIMPLE_BASE, './g','http://a/b/c/g')
         self.checkJoin(SIMPLE_BASE, 'g/','http://a/b/c/g/')
         self.checkJoin(SIMPLE_BASE, '/g','http://a/g')
-        self.checkJoin(SIMPLE_BASE, '//g','http://g/')
+        self.checkJoin(SIMPLE_BASE, '//g','http://g')
         self.checkJoin(SIMPLE_BASE, '?y','http://a/b/c/d?y')
         self.checkJoin(SIMPLE_BASE, 'g?y','http://a/b/c/g?y')
         self.checkJoin(SIMPLE_BASE, 'g?y/./x','http://a/b/c/g?y/./x')
@@ -420,8 +377,10 @@ class UrlParseTestCase(unittest.TestCase):
         self.checkJoin(SIMPLE_BASE, '../g','http://a/b/g')
         self.checkJoin(SIMPLE_BASE, '../..','http://a/')
         self.checkJoin(SIMPLE_BASE, '../../g','http://a/g')
+        self.checkJoin(SIMPLE_BASE, '../../../g','http://a/../g')
         self.checkJoin(SIMPLE_BASE, './../g','http://a/b/g')
         self.checkJoin(SIMPLE_BASE, './g/.','http://a/b/c/g/')
+        self.checkJoin(SIMPLE_BASE, '/./g','http://a/./g')
         self.checkJoin(SIMPLE_BASE, 'g/./h','http://a/b/c/g/h')
         self.checkJoin(SIMPLE_BASE, 'g/../h','http://a/b/c/h')
         self.checkJoin(SIMPLE_BASE, 'http:g','http://a/b/c/g')
@@ -432,32 +391,11 @@ class UrlParseTestCase(unittest.TestCase):
         self.checkJoin('http:///', '..','http:///')
         self.checkJoin('', 'http://a/b/c/g?y/./x','http://a/b/c/g?y/./x')
         self.checkJoin('', 'http://a/./g', 'http://a/./g')
-        self.checkJoin('svn://pathtorepo/dir1', 'dir2', 'svn://pathtorepo/dir2')
-        self.checkJoin('svn+ssh://pathtorepo/dir1', 'dir2', 'svn+ssh://pathtorepo/dir2')
-        self.checkJoin('ws://a/b','g','ws://a/g')
-        self.checkJoin('wss://a/b','g','wss://a/g')
-
-        # XXX: The following tests are no longer compatible with RFC3986
-        # self.checkJoin(SIMPLE_BASE, '../../../g','http://a/../g')
-        # self.checkJoin(SIMPLE_BASE, '/./g','http://a/./g')
-
-        # test for issue22118 duplicate slashes
-        self.checkJoin(SIMPLE_BASE + '/', 'foo', SIMPLE_BASE + '/foo')
-
-        # Non-RFC-defined tests, covering variations of base and trailing
-        # slashes
-        self.checkJoin('http://a/b/c/d/e/', '../../f/g/', 'http://a/b/c/f/g/')
-        self.checkJoin('http://a/b/c/d/e', '../../f/g/', 'http://a/b/f/g/')
-        self.checkJoin('http://a/b/c/d/e/', '/../../f/g/', 'http://a/f/g/')
-        self.checkJoin('http://a/b/c/d/e', '/../../f/g/', 'http://a/f/g/')
-        self.checkJoin('http://a/b/c/d/e/', '../../f/g', 'http://a/b/c/f/g')
-        self.checkJoin('http://a/b/', '../../f/g/', 'http://a/f/g/')
-
-        # issue 23703: don't duplicate filename
-        self.checkJoin('a', 'b', 'b')
+        self.checkJoin('svn://pathtorepo/dir1','dir2','svn://pathtorepo/dir2')
+        self.checkJoin('svn+ssh://pathtorepo/dir1','dir2','svn+ssh://pathtorepo/dir2')
 
     def test_RFC2732(self):
-        str_cases = [
+        for url, hostname, port in [
             ('http://Test.python.org:5432/foo/', 'test.python.org', 5432),
             ('http://12.34.56.78:5432/foo/', '12.34.56.78', 5432),
             ('http://[::1]:5432/foo/', '::1', 5432),
@@ -488,16 +426,20 @@ class UrlParseTestCase(unittest.TestCase):
             ('http://[::12.34.56.78]:/foo/', '::12.34.56.78', None),
             ('http://[::ffff:12.34.56.78]:/foo/',
              '::ffff:12.34.56.78', None),
-            ]
-        def _encode(t):
-            return t[0].encode('ascii'), t[1].encode('ascii'), t[2]
-        bytes_cases = [_encode(x) for x in str_cases]
-        for url, hostname, port in str_cases + bytes_cases:
-            urlparsed = scurl.urlparse(url)
+            ]:
+            urlparsed = urlparse.urlparse(url)
             self.assertEqual((urlparsed.hostname, urlparsed.port) , (hostname, port))
 
+        for invalid_url in [
+                'http://::12.34.56.78]/',
+                'http://[::1/foo/',
+                'ftp://[::1/foo/bad]/bad',
+                'http://[::1/foo/bad]/bad',
+                'http://[::ffff:12.34.56.78']:
+            self.assertRaises(ValueError, urlparse.urlparse, invalid_url)
+
     def test_urldefrag(self):
-        str_cases = [
+        for url, defrag, frag in [
             ('http://python.org#frag', 'http://python.org', 'frag'),
             ('http://python.org', 'http://python.org', ''),
             ('http://python.org/#frag', 'http://python.org/', 'frag'),
@@ -508,30 +450,12 @@ class UrlParseTestCase(unittest.TestCase):
             ('http://python.org/p?q', 'http://python.org/p?q', ''),
             (RFC1808_BASE, 'http://a/b/c/d;p?q', 'f'),
             (RFC2396_BASE, 'http://a/b/c/d;p?q', ''),
-        ]
-        def _encode(t):
-            return type(t)(x.encode('ascii') for x in t)
-        bytes_cases = [_encode(x) for x in str_cases]
-        for url, defrag, frag in str_cases + bytes_cases:
-            result = scurl.urldefrag(url)
-            self.assertEqual(result.geturl(), url)
-            self.assertEqual(result, (defrag, frag))
-            self.assertEqual(result.url, defrag)
-            self.assertEqual(result.fragment, frag)
-
-    @pytest.mark.xfail(reason='zone info, which comes after %, must not be lowercased')
-    def test_urlsplit_scoped_IPv6(self):
-        p = scurl.urlsplit('http://[FE80::822a:a8ff:fe49:470c%tESt]:1234')
-        self.assertEqual(p.hostname, "fe80::822a:a8ff:fe49:470c%tESt")
-        self.assertEqual(p.netloc, '[FE80::822a:a8ff:fe49:470c%tESt]:1234')
-
-        p = scurl.urlsplit(b'http://[FE80::822a:a8ff:fe49:470c%tESt]:1234')
-        self.assertEqual(p.hostname, b"fe80::822a:a8ff:fe49:470c%tESt")
-        self.assertEqual(p.netloc, b'[FE80::822a:a8ff:fe49:470c%tESt]:1234')
+            ]:
+            self.assertEqual(urlparse.urldefrag(url), (defrag, frag))
 
     def test_urlsplit_attributes(self):
         url = "HTTP://WWW.PYTHON.ORG/doc/#frag"
-        p = scurl.urlsplit(url)
+        p = urlparse.urlsplit(url)
         self.assertEqual(p.scheme, "http")
         self.assertEqual(p.netloc, "WWW.PYTHON.ORG")
         self.assertEqual(p.path, "/doc/")
@@ -543,11 +467,10 @@ class UrlParseTestCase(unittest.TestCase):
         self.assertEqual(p.port, None)
         # geturl() won't return exactly the original URL in this case
         # since the scheme is always case-normalized
-        # We handle this by ignoring the first 4 characters of the URL
-        self.assertEqual(p.geturl()[4:], url[4:])
+        #self.assertEqual(p.geturl(), url)
 
         url = "http://User:Pass@www.python.org:080/doc/?query=yes#frag"
-        p = scurl.urlsplit(url)
+        p = urlparse.urlsplit(url)
         self.assertEqual(p.scheme, "http")
         self.assertEqual(p.netloc, "User:Pass@www.python.org:080")
         self.assertEqual(p.path, "/doc/")
@@ -564,7 +487,7 @@ class UrlParseTestCase(unittest.TestCase):
         # and request email addresses as usernames.
 
         url = "http://User@example.com:Pass@www.python.org:080/doc/?query=yes#frag"
-        p = scurl.urlsplit(url)
+        p = urlparse.urlsplit(url)
         self.assertEqual(p.scheme, "http")
         self.assertEqual(p.netloc, "User@example.com:Pass@www.python.org:080")
         self.assertEqual(p.path, "/doc/")
@@ -576,67 +499,61 @@ class UrlParseTestCase(unittest.TestCase):
         self.assertEqual(p.port, 80)
         self.assertEqual(p.geturl(), url)
 
-        # And check them all again, only with bytes this time
-        url = b"HTTP://WWW.PYTHON.ORG/doc/#frag"
-        p = scurl.urlsplit(url)
-        self.assertEqual(p.scheme, b"http")
-        self.assertEqual(p.netloc, b"WWW.PYTHON.ORG")
-        self.assertEqual(p.path, b"/doc/")
-        self.assertEqual(p.query, b"")
-        self.assertEqual(p.fragment, b"frag")
-        self.assertEqual(p.username, None)
-        self.assertEqual(p.password, None)
-        self.assertEqual(p.hostname, b"www.python.org")
+        # Verify an illegal port of value greater than 65535 is set as None
+        url = "http://www.python.org:65536"
+        p = urlparse.urlsplit(url)
         self.assertEqual(p.port, None)
-        self.assertEqual(p.geturl()[4:], url[4:])
 
-        url = b"http://User:Pass@www.python.org:080/doc/?query=yes#frag"
-        p = scurl.urlsplit(url)
-        self.assertEqual(p.scheme, b"http")
-        self.assertEqual(p.netloc, b"User:Pass@www.python.org:080")
-        self.assertEqual(p.path, b"/doc/")
-        self.assertEqual(p.query, b"query=yes")
-        self.assertEqual(p.fragment, b"frag")
-        self.assertEqual(p.username, b"User")
-        self.assertEqual(p.password, b"Pass")
-        self.assertEqual(p.hostname, b"www.python.org")
-        self.assertEqual(p.port, 80)
-        self.assertEqual(p.geturl(), url)
+    def test_issue14072(self):
+        p1 = urlparse.urlsplit('tel:+31-641044153')
+        self.assertEqual(p1.scheme, 'tel')
+        self.assertEqual(p1.path, '+31-641044153')
 
-        url = b"http://User@example.com:Pass@www.python.org:080/doc/?query=yes#frag"
-        p = scurl.urlsplit(url)
-        self.assertEqual(p.scheme, b"http")
-        self.assertEqual(p.netloc, b"User@example.com:Pass@www.python.org:080")
-        self.assertEqual(p.path, b"/doc/")
-        self.assertEqual(p.query, b"query=yes")
-        self.assertEqual(p.fragment, b"frag")
-        self.assertEqual(p.username, b"User@example.com")
-        self.assertEqual(p.password, b"Pass")
-        self.assertEqual(p.hostname, b"www.python.org")
-        self.assertEqual(p.port, 80)
-        self.assertEqual(p.geturl(), url)
+        p2 = urlparse.urlsplit('tel:+31641044153')
+        self.assertEqual(p2.scheme, 'tel')
+        self.assertEqual(p2.path, '+31641044153')
 
-        # Verify an illegal port raises ValueError
-        url = b"HTTP://WWW.PYTHON.ORG:65536/doc/#frag"
-        p = scurl.urlsplit(url)
-        with self.assertRaisesRegex(ValueError, "out of range"):
-            p.port
+        # Assert for urlparse
+        p1 = urlparse.urlparse('tel:+31-641044153')
+        self.assertEqual(p1.scheme, 'tel')
+        self.assertEqual(p1.path, '+31-641044153')
+
+        p2 = urlparse.urlparse('tel:+31641044153')
+        self.assertEqual(p2.scheme, 'tel')
+        self.assertEqual(p2.path, '+31641044153')
+
+
+    def test_telurl_params(self):
+        p1 = urlparse.urlparse('tel:123-4;phone-context=+1-650-516')
+        self.assertEqual(p1.scheme, 'tel')
+        self.assertEqual(p1.path, '123-4')
+        self.assertEqual(p1.params, 'phone-context=+1-650-516')
+
+        p1 = urlparse.urlparse('tel:+1-201-555-0123')
+        self.assertEqual(p1.scheme, 'tel')
+        self.assertEqual(p1.path, '+1-201-555-0123')
+        self.assertEqual(p1.params, '')
+
+        p1 = urlparse.urlparse('tel:7042;phone-context=example.com')
+        self.assertEqual(p1.scheme, 'tel')
+        self.assertEqual(p1.path, '7042')
+        self.assertEqual(p1.params, 'phone-context=example.com')
+
+        p1 = urlparse.urlparse('tel:863-1234;phone-context=+1-914-555')
+        self.assertEqual(p1.scheme, 'tel')
+        self.assertEqual(p1.path, '863-1234')
+        self.assertEqual(p1.params, 'phone-context=+1-914-555')
+
 
     def test_attributes_bad_port(self):
-        """Check handling of invalid ports."""
-        for bytes in (False, True):
-            for parse in (scurl.urlsplit, scurl.urlparse):
-                for port in ("foo", "1.5", "-1", "0x10"):
-                    with self.subTest(bytes=bytes, parse=parse, port=port):
-                        netloc = "www.example.net:" + port
-                        url = "http://" + netloc
-                        if bytes:
-                            netloc = netloc.encode("ascii")
-                            url = url.encode("ascii")
-                        p = parse(url)
-                        self.assertEqual(p.netloc, netloc)
-                        with self.assertRaises(ValueError):
-                            p.port
+        """Check handling of non-integer ports."""
+        p = urlparse.urlsplit("http://www.example.net:foo")
+        self.assertEqual(p.netloc, "www.example.net:foo")
+        self.assertRaises(ValueError, lambda: p.port)
+
+        p = urlparse.urlparse("http://www.example.net:foo")
+        self.assertEqual(p.netloc, "www.example.net:foo")
+        self.assertRaises(ValueError, lambda: p.port)
 
     def test_attributes_without_netloc(self):
         # This example is straight from RFC 3261.  It looks like it
@@ -645,7 +562,7 @@ class UrlParseTestCase(unittest.TestCase):
         # scheme://netloc syntax, the netloc and related attributes
         # should be left empty.
         uri = "sip:alice@atlanta.com;maddr=239.255.255.1;ttl=15"
-        p = scurl.urlsplit(uri)
+        p = urlparse.urlsplit(uri)
         self.assertEqual(p.netloc, "")
         self.assertEqual(p.username, None)
         self.assertEqual(p.password, None)
@@ -653,7 +570,7 @@ class UrlParseTestCase(unittest.TestCase):
         self.assertEqual(p.port, None)
         self.assertEqual(p.geturl(), uri)
 
-        p = scurl.urlparse(uri)
+        p = urlparse.urlparse(uri)
         self.assertEqual(p.netloc, "")
         self.assertEqual(p.username, None)
         self.assertEqual(p.password, None)
@@ -661,334 +578,56 @@ class UrlParseTestCase(unittest.TestCase):
         self.assertEqual(p.port, None)
         self.assertEqual(p.geturl(), uri)
 
-        # You guessed it, repeating the test with bytes input
-        uri = b"sip:alice@atlanta.com;maddr=239.255.255.1;ttl=15"
-        p = scurl.urlsplit(uri)
-        self.assertEqual(p.netloc, b"")
-        self.assertEqual(p.username, None)
-        self.assertEqual(p.password, None)
-        self.assertEqual(p.hostname, None)
-        self.assertEqual(p.port, None)
-        self.assertEqual(p.geturl(), uri)
+    def test_caching(self):
+        # Test case for bug #1313119
+        uri = "http://example.com/doc/"
+        unicode_uri = unicode(uri)
 
-        p = scurl.urlparse(uri)
-        self.assertEqual(p.netloc, b"")
-        self.assertEqual(p.username, None)
-        self.assertEqual(p.password, None)
-        self.assertEqual(p.hostname, None)
-        self.assertEqual(p.port, None)
-        self.assertEqual(p.geturl(), uri)
+        urlparse.urlparse(unicode_uri)
+        p = urlparse.urlparse(uri)
+        self.assertEqual(type(p.scheme), type(uri))
+        self.assertEqual(type(p.hostname), type(uri))
+        self.assertEqual(type(p.path), type(uri))
 
     def test_noslash(self):
         # Issue 1637: http://foo.com?query is legal
-        self.assertEqual(scurl.urlparse("http://example.com?blahblah=/foo"),
+        self.assertEqual(urlparse.urlparse("http://example.com?blahblah=/foo"),
                          ('http', 'example.com', '', '', 'blahblah=/foo', ''))
-        self.assertEqual(scurl.urlparse(b"http://example.com?blahblah=/foo"),
-                         (b'http', b'example.com', b'', b'', b'blahblah=/foo', b''))
 
-    @pytest.mark.xfail(reason='//www.python.org is placed in scheme')
+    def test_anyscheme(self):
+        # Issue 7904: s3://foo.com/stuff has netloc "foo.com".
+        self.assertEqual(urlparse.urlparse("s3://foo.com/stuff"),
+                         ('s3','foo.com','/stuff','','',''))
+        self.assertEqual(urlparse.urlparse("x-newscheme://foo.com/stuff"),
+                         ('x-newscheme','foo.com','/stuff','','',''))
+        self.assertEqual(urlparse.urlparse("x-newscheme://foo.com/stuff?query#fragment"),
+                         ('x-newscheme','foo.com','/stuff','','query','fragment'))
+        self.assertEqual(urlparse.urlparse("x-newscheme://foo.com/stuff?query"),
+                         ('x-newscheme','foo.com','/stuff','','query',''))
+
     def test_withoutscheme(self):
         # Test urlparse without scheme
         # Issue 754016: urlparse goes wrong with IP:port without scheme
         # RFC 1808 specifies that netloc should start with //, urlparse expects
         # the same, otherwise it classifies the portion of url as path.
-        self.assertEqual(scurl.urlparse("path"),
+        self.assertEqual(urlparse.urlparse("path"),
                 ('','','path','','',''))
-        self.assertEqual(scurl.urlparse("//www.python.org:80"),
+        self.assertEqual(urlparse.urlparse("//www.python.org:80"),
                 ('','www.python.org:80','','','',''))
-        self.assertEqual(scurl.urlparse("http://www.python.org:80"),
+        self.assertEqual(urlparse.urlparse("http://www.python.org:80"),
                 ('http','www.python.org:80','','','',''))
-        # Repeat for bytes input
-        self.assertEqual(scurl.urlparse(b"path"),
-                (b'',b'',b'path',b'',b'',b''))
-        self.assertEqual(scurl.urlparse(b"//www.python.org:80"),
-                (b'',b'www.python.org:80',b'',b'',b'',b''))
-        self.assertEqual(scurl.urlparse(b"http://www.python.org:80"),
-                (b'http',b'www.python.org:80',b'',b'',b'',b''))
 
-    @pytest.mark.xfail(reason='path:80 gives path as scheme and 80 as path')
     def test_portseparator(self):
         # Issue 754016 makes changes for port separator ':' from scheme separator
-        self.assertEqual(scurl.urlparse("path:80"),
+        self.assertEqual(urlparse.urlparse("path:80"),
                 ('','','path:80','','',''))
-        self.assertEqual(scurl.urlparse("http:"),('http','','','','',''))
-        self.assertEqual(scurl.urlparse("https:"),('https','','','','',''))
-        self.assertEqual(scurl.urlparse("http://www.python.org:80"),
+        self.assertEqual(urlparse.urlparse("http:"),('http','','','','',''))
+        self.assertEqual(urlparse.urlparse("https:"),('https','','','','',''))
+        self.assertEqual(urlparse.urlparse("http://www.python.org:80"),
                 ('http','www.python.org:80','','','',''))
-        # As usual, need to check bytes input as well
-        self.assertEqual(scurl.urlparse(b"path:80"),
-                (b'',b'',b'path:80',b'',b'',b''))
-        self.assertEqual(scurl.urlparse(b"http:"),(b'http',b'',b'',b'',b'',b''))
-        self.assertEqual(scurl.urlparse(b"https:"),(b'https',b'',b'',b'',b'',b''))
-        self.assertEqual(scurl.urlparse(b"http://www.python.org:80"),
-                (b'http',b'www.python.org:80',b'',b'',b'',b''))
 
-    def test_usingsys(self):
-        # Issue 3314: sys module is used in the error
-        self.assertRaises(TypeError, scurl.urlencode, "foo")
-
-    @pytest.mark.xfail(reason='GURL cannot handle schemes such as "s3"')
-    def test_anyscheme(self):
-        # Issue 7904: s3://foo.com/stuff has netloc "foo.com".
-        self.assertEqual(scurl.urlparse("s3://foo.com/stuff"),
-                         ('s3', 'foo.com', '/stuff', '', '', ''))
-        self.assertEqual(scurl.urlparse("x-newscheme://foo.com/stuff"),
-                         ('x-newscheme', 'foo.com', '/stuff', '', '', ''))
-        self.assertEqual(scurl.urlparse("x-newscheme://foo.com/stuff?query#fragment"),
-                         ('x-newscheme', 'foo.com', '/stuff', '', 'query', 'fragment'))
-        self.assertEqual(scurl.urlparse("x-newscheme://foo.com/stuff?query"),
-                         ('x-newscheme', 'foo.com', '/stuff', '', 'query', ''))
-
-        # And for bytes...
-        self.assertEqual(scurl.urlparse(b"s3://foo.com/stuff"),
-                         (b's3', b'foo.com', b'/stuff', b'', b'', b''))
-        self.assertEqual(scurl.urlparse(b"x-newscheme://foo.com/stuff"),
-                         (b'x-newscheme', b'foo.com', b'/stuff', b'', b'', b''))
-        self.assertEqual(scurl.urlparse(b"x-newscheme://foo.com/stuff?query#fragment"),
-                         (b'x-newscheme', b'foo.com', b'/stuff', b'', b'query', b'fragment'))
-        self.assertEqual(scurl.urlparse(b"x-newscheme://foo.com/stuff?query"),
-                         (b'x-newscheme', b'foo.com', b'/stuff', b'', b'query', b''))
-
-    def test_default_scheme(self):
-        # Exercise the scheme parameter of urlparse() and urlsplit()
-        for func in (scurl.urlparse, scurl.urlsplit):
-            with self.subTest(function=func):
-                result = func("http://example.net/", "ftp")
-                self.assertEqual(result.scheme, "http")
-                result = func(b"http://example.net/", b"ftp")
-                self.assertEqual(result.scheme, b"http")
-                self.assertEqual(func("path", "ftp").scheme, "ftp")
-                self.assertEqual(func("path", scheme="ftp").scheme, "ftp")
-                self.assertEqual(func(b"path", scheme=b"ftp").scheme, b"ftp")
-                self.assertEqual(func("path").scheme, "")
-                self.assertEqual(func(b"path").scheme, b"")
-                self.assertEqual(func(b"path", "").scheme, b"")
-
-    @pytest.mark.xfail(reason='allow_fragments is not implemented yet')
-    def test_parse_fragments(self):
-        # Exercise the allow_fragments parameter of urlparse() and urlsplit()
-        tests = (
-            ("http:#frag", "path", "frag"),
-            ("//example.net#frag", "path", "frag"),
-            ("index.html#frag", "path", "frag"),
-            (";a=b#frag", "params", "frag"),
-            ("?a=b#frag", "query", "frag"),
-            ("#frag", "path", "frag"),
-            ("abc#@frag", "path", "@frag"),
-            ("//abc#@frag", "path", "@frag"),
-            ("//abc:80#@frag", "path", "@frag"),
-            ("//abc#@frag:80", "path", "@frag:80"),
-        )
-        for url, attr, expected_frag in tests:
-            for func in (scurl.urlparse, scurl.urlsplit):
-                if attr == "params" and func is scurl.urlsplit:
-                    attr = "path"
-                with self.subTest(url=url, function=func):
-                    result = func(url, allow_fragments=False)
-                    self.assertEqual(result.fragment, "")
-                    self.assertTrue(
-                            getattr(result, attr).endswith("#" + expected_frag))
-                    self.assertEqual(func(url, "", False).fragment, "")
-
-                    result = func(url, allow_fragments=True)
-                    self.assertEqual(result.fragment, expected_frag)
-                    self.assertFalse(
-                            getattr(result, attr).endswith(expected_frag))
-                    self.assertEqual(func(url, "", True).fragment,
-                                     expected_frag)
-                    self.assertEqual(func(url).fragment, expected_frag)
-
-    def test_mixed_types_rejected(self):
-        # Several functions that process either strings or ASCII encoded bytes
-        # accept multiple arguments. Check they reject mixed type input
-        with self.assertRaisesRegex(TypeError, "Cannot mix str"):
-            scurl.urlparse("www.python.org", b"http")
-        with self.assertRaisesRegex(TypeError, "Cannot mix str"):
-            scurl.urlparse(b"www.python.org", "http")
-        with self.assertRaisesRegex(TypeError, "Cannot mix str"):
-            scurl.urlsplit("www.python.org", b"http")
-        with self.assertRaisesRegex(TypeError, "Cannot mix str"):
-            scurl.urlsplit(b"www.python.org", "http")
-        with self.assertRaisesRegex(TypeError, "Cannot mix str"):
-            scurl.urlunparse(( b"http", "www.python.org","","","",""))
-        with self.assertRaisesRegex(TypeError, "Cannot mix str"):
-            scurl.urlunparse(("http", b"www.python.org","","","",""))
-        with self.assertRaisesRegex(TypeError, "Cannot mix str"):
-            scurl.urlunsplit((b"http", "www.python.org","","",""))
-        with self.assertRaisesRegex(TypeError, "Cannot mix str"):
-            scurl.urlunsplit(("http", b"www.python.org","","",""))
-        with self.assertRaisesRegex(TypeError, "Cannot mix str"):
-            scurl.urljoin("http://python.org", b"http://python.org")
-        with self.assertRaisesRegex(TypeError, "Cannot mix str"):
-            scurl.urljoin(b"http://python.org", "http://python.org")
-
-    def _check_result_type(self, str_type):
-        num_args = len(str_type._fields)
-        bytes_type = str_type._encoded_counterpart
-        self.assertIs(bytes_type._decoded_counterpart, str_type)
-        str_args = ('',) * num_args
-        bytes_args = (b'',) * num_args
-        str_result = str_type(*str_args)
-        bytes_result = bytes_type(*bytes_args)
-        encoding = 'ascii'
-        errors = 'strict'
-        self.assertEqual(str_result, str_args)
-        self.assertEqual(bytes_result.decode(), str_args)
-        self.assertEqual(bytes_result.decode(), str_result)
-        self.assertEqual(bytes_result.decode(encoding), str_args)
-        self.assertEqual(bytes_result.decode(encoding), str_result)
-        self.assertEqual(bytes_result.decode(encoding, errors), str_args)
-        self.assertEqual(bytes_result.decode(encoding, errors), str_result)
-        self.assertEqual(bytes_result, bytes_args)
-        self.assertEqual(str_result.encode(), bytes_args)
-        self.assertEqual(str_result.encode(), bytes_result)
-        self.assertEqual(str_result.encode(encoding), bytes_args)
-        self.assertEqual(str_result.encode(encoding), bytes_result)
-        self.assertEqual(str_result.encode(encoding, errors), bytes_args)
-        self.assertEqual(str_result.encode(encoding, errors), bytes_result)
-
-    def test_result_pairs(self):
-        # Check encoding and decoding between result pairs
-        result_types = [
-          scurl.DefragResult,
-          scurl.SplitResult,
-          scurl.ParseResult,
-        ]
-        for result_type in result_types:
-            self._check_result_type(result_type)
-
-    def test_parse_qs_encoding(self):
-        result = scurl.parse_qs("key=\u0141%E9", encoding="latin-1")
-        self.assertEqual(result, {'key': ['\u0141\xE9']})
-        result = scurl.parse_qs("key=\u0141%C3%A9", encoding="utf-8")
-        self.assertEqual(result, {'key': ['\u0141\xE9']})
-        result = scurl.parse_qs("key=\u0141%C3%A9", encoding="ascii")
-        self.assertEqual(result, {'key': ['\u0141\ufffd\ufffd']})
-        result = scurl.parse_qs("key=\u0141%E9-", encoding="ascii")
-        self.assertEqual(result, {'key': ['\u0141\ufffd-']})
-        result = scurl.parse_qs("key=\u0141%E9-", encoding="ascii",
-                                                          errors="ignore")
-        self.assertEqual(result, {'key': ['\u0141-']})
-
-    def test_parse_qsl_encoding(self):
-        result = scurl.parse_qsl("key=\u0141%E9", encoding="latin-1")
-        self.assertEqual(result, [('key', '\u0141\xE9')])
-        result = scurl.parse_qsl("key=\u0141%C3%A9", encoding="utf-8")
-        self.assertEqual(result, [('key', '\u0141\xE9')])
-        result = scurl.parse_qsl("key=\u0141%C3%A9", encoding="ascii")
-        self.assertEqual(result, [('key', '\u0141\ufffd\ufffd')])
-        result = scurl.parse_qsl("key=\u0141%E9-", encoding="ascii")
-        self.assertEqual(result, [('key', '\u0141\ufffd-')])
-        result = scurl.parse_qsl("key=\u0141%E9-", encoding="ascii",
-                                                          errors="ignore")
-        self.assertEqual(result, [('key', '\u0141-')])
-
-    def test_urlencode_sequences(self):
-        # Other tests incidentally urlencode things; test non-covered cases:
-        # Sequence and object values.
-        result = scurl.urlencode({'a': [1, 2], 'b': (3, 4, 5)}, True)
-        # we cannot rely on ordering here
-        assert set(result.split('&')) == {'a=1', 'a=2', 'b=3', 'b=4', 'b=5'}
-
-        class Trivial:
-            def __str__(self):
-                return 'trivial'
-
-        result = scurl.urlencode({'a': Trivial()}, True)
-        self.assertEqual(result, 'a=trivial')
-
-    @pytest.mark.skipif(sys.version_info < (3,5),
-                        reason="quote_via is not implemented in py34")
-    def test_urlencode_quote_via(self):
-        result = scurl.urlencode({'a': 'some value'})
-        self.assertEqual(result, "a=some+value")
-        result = scurl.urlencode({'a': 'some value/another'},
-                                        quote_via=scurl.quote)
-        self.assertEqual(result, "a=some%20value%2Fanother")
-        result = scurl.urlencode({'a': 'some value/another'},
-                                        safe='/', quote_via=scurl.quote)
-        self.assertEqual(result, "a=some%20value/another")
-
-    def test_quote_from_bytes(self):
-        self.assertRaises(TypeError, scurl.quote_from_bytes, 'foo')
-        result = scurl.quote_from_bytes(b'archaeological arcana')
-        self.assertEqual(result, 'archaeological%20arcana')
-        result = scurl.quote_from_bytes(b'')
-        self.assertEqual(result, '')
-
-    def test_unquote_to_bytes(self):
-        result = scurl.unquote_to_bytes('abc%20def')
-        self.assertEqual(result, b'abc def')
-        result = scurl.unquote_to_bytes('')
-        self.assertEqual(result, b'')
-
-    def test_quote_errors(self):
-        self.assertRaises(TypeError, scurl.quote, b'foo',
-                          encoding='utf-8')
-        self.assertRaises(TypeError, scurl.quote, b'foo', errors='strict')
-
-    def test_issue14072(self):
-        p1 = scurl.urlsplit('tel:+31-641044153')
-        self.assertEqual(p1.scheme, 'tel')
-        self.assertEqual(p1.path, '+31-641044153')
-        p2 = scurl.urlsplit('tel:+31641044153')
-        self.assertEqual(p2.scheme, 'tel')
-        self.assertEqual(p2.path, '+31641044153')
-        # assert the behavior for urlparse
-        p1 = scurl.urlparse('tel:+31-641044153')
-        self.assertEqual(p1.scheme, 'tel')
-        self.assertEqual(p1.path, '+31-641044153')
-        p2 = scurl.urlparse('tel:+31641044153')
-        self.assertEqual(p2.scheme, 'tel')
-        self.assertEqual(p2.path, '+31641044153')
-
-    def test_port_casting_failure_message(self):
-        message = "Port could not be"
-        p1 = scurl.urlparse('http://Server=sde; Service=sde:oracle')
-        with self.assertRaisesRegex(ValueError, message):
-            p1.port
-
-        p2 = scurl.urlsplit('http://Server=sde; Service=sde:oracle')
-        with self.assertRaisesRegex(ValueError, message):
-            p2.port
-
-    def test_telurl_params(self):
-        p1 = scurl.urlparse('tel:123-4;phone-context=+1-650-516')
-        self.assertEqual(p1.scheme, 'tel')
-        self.assertEqual(p1.path, '123-4')
-        self.assertEqual(p1.params, 'phone-context=+1-650-516')
-
-        p1 = scurl.urlparse('tel:+1-201-555-0123')
-        self.assertEqual(p1.scheme, 'tel')
-        self.assertEqual(p1.path, '+1-201-555-0123')
-        self.assertEqual(p1.params, '')
-
-        p1 = scurl.urlparse('tel:7042;phone-context=example.com')
-        self.assertEqual(p1.scheme, 'tel')
-        self.assertEqual(p1.path, '7042')
-        self.assertEqual(p1.params, 'phone-context=example.com')
-
-        p1 = scurl.urlparse('tel:863-1234;phone-context=+1-914-555')
-        self.assertEqual(p1.scheme, 'tel')
-        self.assertEqual(p1.path, '863-1234')
-        self.assertEqual(p1.params, 'phone-context=+1-914-555')
-
-    @pytest.mark.xfail(reason='GURL failed to join http://a/b/c/d;p?q#f and " "')
-    def test_join_xfailed_RFC1808(self):
-        # "abnormal" cases from RFC 1808:
-        self.checkJoin(RFC1808_BASE, '', 'http://a/b/c/d;p?q#f')
-
-    @pytest.mark.xfail(reason='GURL havent handled invalid ipv6 urls yet')
-    def test_test_RFC2732_valueerror_not_raised(self):
-        str_cases = [
-                'http://::12.34.56.78]/',
-                'http://[::1/foo/',
-                'ftp://[::1/foo/bad]/bad',
-                'http://[::1/foo/bad]/bad',
-                'http://[::ffff:12.34.56.78']
-        bytes_cases = [x.encode('ascii') for x in str_cases]
-        for invalid_url in str_cases + bytes_cases:
-            self.assertRaises(ValueError, scurl.urlparse, invalid_url)
+def test_main():
+    test_support.run_unittest(UrlParseTestCase)
 
 if __name__ == "__main__":
-    unittest.main()
+    test_main()


### PR DESCRIPTION
This PR restores all the tests from urllib, since the current tests in Scurl are modified to pass the tests. However, we need Scurl to act similar to urllib 😄 